### PR TITLE
参加者の休会/退会に伴う処理実装

### DIFF
--- a/backend/src/domain/domain-service/participant-deactivate.ts
+++ b/backend/src/domain/domain-service/participant-deactivate.ts
@@ -34,7 +34,8 @@ export class ParticipantDeactivate {
       // 参加人数が少ないペアも定員で合流できない場合
       if (fewestPair.getParticipantCount() > 2) {
         targetTeam.addPair(targetPair)
-        console.log('管理者宛にメール送信')
+        // TODO: コンソール出力 -> 管理者へのメール送信に処理を変更する
+        console.log(`${targetParticipant.getName()}さんが抜けました.`)
         // 休会/退会によってペアが残された参加者1名になってしまう場合
       } else if (targetPair.getParticipantCount() < 2) {
         const leftParticipants = targetPair.getParticipants()
@@ -52,6 +53,14 @@ export class ParticipantDeactivate {
       // チーム内に他のペアがいない場合
     } else {
       targetTeam.addPair(targetPair)
+    }
+
+    // 休会/退会によってチームが2名以下になる場合
+    if (targetTeam.getParticipantCount() <= 2) {
+      // TODO: コンソール出力 -> 管理者へのメール送信に処理を変更する
+      console.log(
+        `${targetParticipant.getName()}さんが抜けたことによって、チーム${targetTeam.getName()}が${targetTeam.getParticipantCount()}名になりました.`,
+      )
     }
 
     this.participantRepo.updateTeam(targetTeam)

--- a/backend/src/domain/domain-service/participant-deactivate.ts
+++ b/backend/src/domain/domain-service/participant-deactivate.ts
@@ -20,10 +20,30 @@ export class ParticipantDeactivate {
     const targetParticipant = targetPair.getParticipantByParticipantId(id)
 
     // TODO: 参加者の減少でチームが2名以下になってしまう場合、管理者にメールが送信されるように修正
-    // TODO: 参加者の減少でペアが1名以下になってしまう場合、残った参加者が自動的に他のペアに合流するように修正
-    targetPair.removeParticipant(id)
     targetTeam.removePair(targetPair.getId())
-    targetTeam.addPair(targetPair)
+    targetPair.removeParticipant(id)
+
+    // 参加者の減少でペアが1名以下になる場合、残った参加者を同じチームの人数が少ないペアに合流させる
+    if (targetPair.getParticipantCount() < 2) {
+      // 同じチームの参加人数が少ないペア取得
+      const fewestPair = targetTeam.getPairWithFewestParticipants()
+
+      // 残されたペアの残された参加者取得
+      const lonelyParticipants = targetPair.getParticipants()
+
+      // 少ないペアにその参加者を移動させる
+      lonelyParticipants.forEach((participant) =>
+        fewestPair.addParticipant(participant),
+      )
+
+      // 残ったペアは消す
+      targetTeam.removePair(targetPair.getId())
+
+      targetTeam.removePair(fewestPair.getId())
+      targetTeam.addPair(fewestPair)
+    } else {
+      targetTeam.addPair(targetPair)
+    }
 
     this.participantRepo.updateTeam(targetTeam)
 

--- a/backend/src/domain/domain-service/participant-deactivate.ts
+++ b/backend/src/domain/domain-service/participant-deactivate.ts
@@ -1,3 +1,5 @@
+import { Team } from 'src/domain/entity/team'
+import { Pair } from 'src/domain/entity/pair'
 import { RemovedParticipant } from 'src/domain/entity/removed-participant'
 import { IParticipantRepository } from 'src/app/repository-interface/participant-repository'
 import { IRemovedParticipantRepository } from 'src/app/repository-interface/removed-participant-repository'
@@ -32,12 +34,16 @@ export class ParticipantDeactivate {
     // 参加者が休会/退会したペア以外にも、チーム内にペアがいる場合
     if (fewestPair) {
       // 参加人数が少ないペアも定員で合流できない場合
-      if (fewestPair.getParticipantCount() > 2) {
+      if (
+        fewestPair.getParticipantCount() >= Pair.MAXIMUM_NUMBER_OF_PARTICIPANTS
+      ) {
         targetTeam.addPair(targetPair)
         // TODO: コンソール出力 -> 管理者へのメール送信に処理を変更する
         console.log(`${targetParticipant.getName()}さんが抜けました.`)
         // 休会/退会によってペアが残された参加者1名になってしまう場合
-      } else if (targetPair.getParticipantCount() < 2) {
+      } else if (
+        targetPair.getParticipantCount() < Pair.MINIIMUM_NUMBER_OF_PARTICIPANTS
+      ) {
         const leftParticipants = targetPair.getParticipants()
 
         leftParticipants.forEach((participant) =>
@@ -56,7 +62,9 @@ export class ParticipantDeactivate {
     }
 
     // 休会/退会によってチームが2名以下になる場合
-    if (targetTeam.getParticipantCount() <= 2) {
+    if (
+      targetTeam.getParticipantCount() <= Team.MINIIMUM_NUMBER_OF_PARTICIPANTS
+    ) {
       // TODO: コンソール出力 -> 管理者へのメール送信に処理を変更する
       console.log(
         `${targetParticipant.getName()}さんが抜けたことによって、チーム${targetTeam.getName()}が${targetTeam.getParticipantCount()}名になりました.`,

--- a/backend/src/domain/entity/__tests__/team.test.ts
+++ b/backend/src/domain/entity/__tests__/team.test.ts
@@ -96,6 +96,10 @@ describe('Pairのテスト', () => {
       expect(team.getId()).toMatch(/[0-9|a-z|-]{36}/)
     })
 
+    it('getName()でチーム名の取得が行えること', () => {
+      expect(team.getName()).toBe('1')
+    })
+
     it('getPairs()でチームに所属するペアの取得が行えること', () => {
       expect(team.getPairs()).toContain(pair1)
       expect(team.getPairs()).toContain(pair2)

--- a/backend/src/domain/entity/__tests__/team.test.ts
+++ b/backend/src/domain/entity/__tests__/team.test.ts
@@ -111,6 +111,10 @@ describe('Pairのテスト', () => {
       expect(team.getPairWithFewestParticipants()).toBe(pair1)
     })
 
+    it('getParticipantCount()でチームに所属する人数の取得が行えること', () => {
+      expect(team.getParticipantCount()).toBe(5)
+    })
+
     it('addPair()でチームに所属するペアの追加が行えること', () => {
       team.addPair(pair3)
       expect(team.getPairs()).toContain(pair3)

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -25,6 +25,10 @@ export class Team {
     return this.id
   }
 
+  public getName() {
+    return this.name.getValue()
+  }
+
   public getPairs() {
     return this.pairs
   }

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -2,6 +2,8 @@ import { Pair } from 'src/domain/entity/pair'
 import { Participant } from 'src/domain/entity/participant'
 
 export class Team {
+  static readonly MINIIMUM_NUMBER_OF_PARTICIPANTS: number = 2
+
   private id: string
   private name: TeamNameVO
   private pairs: Pair[]

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -63,6 +63,13 @@ export class Team {
     return pairWithFewestParticipants
   }
 
+  public getParticipantCount(): number {
+    return this.pairs.reduce(
+      (count, pair) => count + pair.getParticipantCount(),
+      0,
+    )
+  }
+
   public addPair(pair: Pair): void {
     this.pairs.push(pair)
   }


### PR DESCRIPTION
### 実装したもの
- 参加者のステータス変更（在籍中->休会/退会）を行なった時に
  - ペアの人数が規定の人数を下回った場合、自動的に他のペアに合流するように修正
  - チームの人数が規定の人数を下回った場合、メール送信する条件分岐を追加 

### 実装していないもの
- 実際にメール送信を行う処理