### PR TITLE
参加者の休会/退会からの復帰にトランザクションを追加

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,9 +23,10 @@
     "migrate:dev:reset": "dotenv -e .local.env -- prisma migrate reset --preview-feature",
     "migrate:test": "dotenv -e .test.env -- prisma migrate reset --force --preview-feature",
     "migrate:prd": "prisma migrate deploy --preview-feature",
-    "seed:dev": "dotenv -e .local.env -- ts-node prisma/seed.ts",
+    "seed:dev": "dotenv -e .local.env -- ts-node prisma/dev-seed.ts",
+    "seed:test": "dotenv -e .test.env -- ts-node prisma/test-seed.ts",
     "test:unit": "dotenv -e .test.env -- jest",
-    "test:integration": "yarn migrate:test && dotenv -e .test.env -- jest -c ./jest.integration.config.js --runInBand"
+    "test:integration": "yarn migrate:test && yarn seed:test && dotenv -e .test.env -- jest -c ./jest.integration.config.js --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",

--- a/backend/prisma/dev-seed.ts
+++ b/backend/prisma/dev-seed.ts
@@ -1,0 +1,367 @@
+import { PrismaClient } from '@prisma/client'
+import { createRandomIdString } from '../src/util/random'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const delete1 = await prisma.$transaction([
+    prisma.participantOnTask.deleteMany(),
+    prisma.participant.deleteMany(),
+    prisma.removedParticipant.deleteMany(),
+    prisma.pair.deleteMany(),
+    prisma.team.deleteMany(),
+    prisma.task.deleteMany(),
+    prisma.participantStatus.deleteMany(),
+    prisma.removedParticipantStatus.deleteMany(),
+    prisma.taskStatus.deleteMany(),
+  ])
+
+  const participantStatus = await prisma.participantStatus.createMany({
+    data: [{ id: '1', name: '在籍中' }],
+  })
+
+  const removedParticipantStatus = await prisma.removedParticipantStatus.createMany(
+    {
+      data: [
+        { id: '2', name: '休会中' },
+        { id: '3', name: '退会済' },
+      ],
+    },
+  )
+
+  const taskStatus = await prisma.taskStatus.createMany({
+    data: [
+      { id: '1', name: '未着手' },
+      { id: '2', name: 'レビュー待ち' },
+      { id: '3', name: '完了' },
+    ],
+  })
+
+  const task = await prisma.task.createMany({
+    data: [
+      { id: '1', title: '課題1', content: 'DB設計の課題1です.' },
+      { id: '2', title: '課題2', content: 'DB設計の課題2です.' },
+      { id: '3', title: '課題3', content: 'DB設計の課題3です.' },
+      { id: '4', title: '課題4', content: 'DB設計の課題4です.' },
+    ],
+  })
+
+  const team_1 = await prisma.team.create({
+    data: {
+      id: createRandomIdString(),
+      name: '1',
+      pairs: {
+        create: [
+          {
+            id: createRandomIdString(),
+            name: 'a',
+            participants: {
+              create: [
+                {
+                  id: '1',
+                  name: 'Alice',
+                  email: 'alice@example.com',
+                  statusId: '1',
+                },
+                {
+                  id: '2',
+                  name: 'Bob',
+                  email: 'bob@example.com',
+                  statusId: '1',
+                },
+              ],
+            },
+          },
+          {
+            id: createRandomIdString(),
+            name: 'b',
+            participants: {
+              create: [
+                {
+                  id: '3',
+                  name: 'Cachy',
+                  email: 'cachy@example.com',
+                  statusId: '1',
+                },
+                {
+                  id: '4',
+                  name: 'Dan',
+                  email: 'dan@example.com',
+                  statusId: '1',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  })
+
+  const team_2 = await prisma.team.create({
+    data: {
+      id: createRandomIdString(),
+      name: '2',
+      pairs: {
+        create: [
+          {
+            id: createRandomIdString(),
+            name: 'c',
+            participants: {
+              create: [
+                {
+                  id: '5',
+                  name: 'Evans',
+                  email: 'evans@example.com',
+                  statusId: '1',
+                },
+                {
+                  id: '6',
+                  name: 'Falco',
+                  email: 'falco@example.com',
+                  statusId: '1',
+                },
+              ],
+            },
+          },
+          {
+            id: createRandomIdString(),
+            name: 'd',
+            participants: {
+              create: [
+                {
+                  id: '7',
+                  name: 'Gen',
+                  email: 'gen@example.com',
+                  statusId: '1',
+                },
+                {
+                  id: '8',
+                  name: 'Holly',
+                  email: 'holly@example.com',
+                  statusId: '1',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  })
+
+  const removedParticipant = await prisma.removedParticipant.createMany({
+    data: [
+      {
+        id: '9',
+        name: 'Shinya',
+        email: 'shinya@example.com',
+        statusId: '2',
+      },
+    ],
+  })
+
+  const participantOnTask = await prisma.participantOnTask.createMany({
+    data: [
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '1',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '1',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '1',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '1',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '2',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '2',
+        participantId: '2',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '2',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '2',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '3',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '3',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '3',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '3',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '4',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '4',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '4',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '4',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '5',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '5',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '5',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '5',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '6',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '6',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '6',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '6',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '7',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '7',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '7',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '7',
+        taskId: '4',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '8',
+        taskId: '1',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '8',
+        taskId: '2',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '8',
+        taskId: '3',
+      },
+      {
+        id: createRandomIdString(),
+        statusId: '1',
+        participantId: '8',
+        taskId: '4',
+      },
+    ],
+  })
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/backend/prisma/test-seed.ts
+++ b/backend/prisma/test-seed.ts
@@ -148,6 +148,23 @@ async function main() {
     },
   })
 
+  const removedParticipant = await prisma.removedParticipant.createMany({
+    data: [
+      {
+        id: '8',
+        name: 'Kai',
+        email: 'kai@example.com',
+        statusId: '2',
+      },
+      {
+        id: '9',
+        name: 'Shinya',
+        email: 'shinya@example.com',
+        statusId: '2',
+      },
+    ],
+  })
+
   const participantOnTask = await prisma.participantOnTask.createMany({
     data: [
       {

--- a/backend/src/app/update-participant-status-usecase.ts
+++ b/backend/src/app/update-participant-status-usecase.ts
@@ -1,3 +1,4 @@
+import { PrismaClient } from '@prisma/client'
 import { ParticipantStatus } from 'src/domain/entity/participant-status-id-vo'
 import { RemovedParticipantStatus } from 'src/domain/entity/removed-participant-status-id-vo'
 import { IParticipantQS } from 'src/app/query-service-interface/participant-qs'
@@ -8,15 +9,18 @@ import { ParticipantActivate } from 'src/domain/domain-service/participant-activ
 import { ParticipantDeactivate } from 'src/domain/domain-service/participant-deactivate'
 
 export class UpdateParticipantUseCase {
+  private readonly prismaClient: PrismaClient
   private readonly participantQS: IParticipantQS
   private readonly participantRepo: IParticipantRepository
   private readonly removedParticipantRepo: IRemovedParticipantRepository
 
   public constructor(
+    prismaClient: PrismaClient,
     participantQS: IParticipantQS,
     participantRepo: IParticipantRepository,
     removedParticipantRepo: IRemovedParticipantRepository,
   ) {
+    this.prismaClient = prismaClient
     this.participantQS = participantQS
     this.participantRepo = participantRepo
     this.removedParticipantRepo = removedParticipantRepo
@@ -28,6 +32,7 @@ export class UpdateParticipantUseCase {
     if (statusId === ParticipantStatus.Enrolled) {
       // RemovedParticipant -> Participant
       const participantActivateService = new ParticipantActivate(
+        this.prismaClient,
         this.participantRepo,
         this.removedParticipantRepo,
       )

--- a/backend/src/controller/participant.controller.ts
+++ b/backend/src/controller/participant.controller.ts
@@ -52,6 +52,7 @@ export class ParticipantController {
     const participantRepo = new ParticipantRepository(prisma)
     const removedParticipantRepo = new RemovedParticipantRepository(prisma)
     const usecase = new UpdateParticipantUseCase(
+      prisma,
       qs,
       participantRepo,
       removedParticipantRepo,

--- a/backend/src/domain/domain-service/__tests__/participant-activate.integration.test.ts
+++ b/backend/src/domain/domain-service/__tests__/participant-activate.integration.test.ts
@@ -1,0 +1,53 @@
+import { PrismaClient } from '@prisma/client'
+import { ParticipantRepository } from 'src/infra/db/repository/participant-repository'
+import { RemovedParticipantRepository } from 'src/infra/db/repository/removed-participant-repository'
+import { ParticipantActivate } from '../participant-activate'
+import { Participant } from 'src/domain/entity/participant'
+import { RemovedParticipant } from 'src/domain/entity/removed-participant'
+
+describe('do', () => {
+  const prisma = new PrismaClient()
+  const participantRepo = new ParticipantRepository(prisma)
+  const removedParticipantRepo = new RemovedParticipantRepository(prisma)
+  const participantActivateService = new ParticipantActivate(
+    prisma,
+    participantRepo,
+    removedParticipantRepo,
+  )
+
+  it('対象の休会/退会参加者が存在する場合、①参加者として追加され ②休会/退会参加者からは削除されること', async () => {
+    const removedParticipantId = '9'
+
+    await participantActivateService.participantActivate(removedParticipantId)
+
+    const targetTeam = await participantRepo.getTeamByParticipantId(
+      removedParticipantId,
+    )
+    const targetPair = targetTeam.getPairByParticipantId(removedParticipantId)
+
+    expect(
+      targetPair.getParticipantByParticipantId(removedParticipantId),
+    ).toBeInstanceOf(Participant) // ①
+
+    await expect(
+      removedParticipantRepo.getRemovedParticipantByParticipantId(
+        removedParticipantId,
+      ),
+    ).resolves.toBeNull() // ②
+  })
+
+  it('復帰した参加者の追加に失敗した場合、①participantActivateでエラーが発生し ②休会/退会参加者の削除も行われないこと', async () => {
+    // Participantテーブルにも存在するIDを指定し、Participantテーブルへの挿入を失敗させる
+    const removedParticipantId = '8'
+
+    await expect(
+      participantActivateService.participantActivate(removedParticipantId),
+    ).rejects.toThrow() // ①
+
+    await expect(
+      removedParticipantRepo.getRemovedParticipantByParticipantId(
+        removedParticipantId,
+      ),
+    ).resolves.toBeInstanceOf(RemovedParticipant) // ②
+  })
+})

--- a/backend/src/domain/domain-service/__tests__/participant-activate.test.ts
+++ b/backend/src/domain/domain-service/__tests__/participant-activate.test.ts
@@ -12,11 +12,11 @@ jest.mock('src/infra/db/repository/participant-repository')
 jest.mock('src/infra/db/repository/removed-participant-repository')
 
 describe('do', () => {
+  const prisma = new PrismaClient()
   let mockParticipantRepo: MockedObjectDeep<ParticipantRepository>
   let mockRemovedParticipantRepo: MockedObjectDeep<RemovedParticipantRepository>
 
   beforeAll(() => {
-    const prisma = new PrismaClient()
     mockParticipantRepo = mocked(new ParticipantRepository(prisma), true)
     mockRemovedParticipantRepo = mocked(
       new RemovedParticipantRepository(prisma),
@@ -34,6 +34,7 @@ describe('do', () => {
     )
 
     const participantActivateService = new ParticipantActivate(
+      prisma,
       mockParticipantRepo,
       mockRemovedParticipantRepo,
     )
@@ -51,6 +52,7 @@ describe('do', () => {
     )
 
     const participantActivateService = new ParticipantActivate(
+      prisma,
       mockParticipantRepo,
       mockRemovedParticipantRepo,
     )


### PR DESCRIPTION
### 実装したもの
- 複数集約を更新するドメインサービスにおけるトランザクション処理
- seedファイルを開発用/テスト用で分割
  - テスト用では任意の箇所でエラーを発生させるために不整合なデータを投入したため
- テスト用DBに接続して行うドメインサービスの結合テスト 

### 確認してほしい箇所
- package.jsonに記述したyarn test:integrationの処理内容
- participant-activate.integration.test.tsに記述した結合テストの内容

お忙しいところ申し訳ありませんが、お目通しいただけると幸いです。