### PR TITLE
getUsers()を使用しないように修正

### DIFF
--- a/backend/src/domain/domain-service/user-activate.ts
+++ b/backend/src/domain/domain-service/user-activate.ts
@@ -46,9 +46,8 @@ export class UserActivate {
     // ペアに参加させた結果、ペアの定員を超えてしまわないか確認する
     if (targetPair.getUserCount() > Pair.MAXIMUM_NUMBER_OF_PARTICIPANTS) {
       // ペアの定員を超えてしまう場合、最も参加人数が少ないペアのうち1人と新規参加者で新しいペアを作成する
-      const users = targetPair.getUsers()
-      const choicedUser = users[0]
-      targetPair.removeUser(choicedUser!.getId())
+      const choicedUser = targetPair.getFirstUser()
+      targetPair.removeUser(choicedUser.getId())
 
       const newPair = new Pair({
         id: createRandomIdString(),
@@ -105,7 +104,7 @@ export class UserActivate {
               id: pair.getId(),
               name: pair.getName(),
               users: {
-                create: pair.getUsers().map((user) => {
+                create: pair.getUsersInRepository().map((user) => {
                   return {
                     id: user.getId(),
                     name: user.getName(),

--- a/backend/src/domain/domain-service/user-deactivate.ts
+++ b/backend/src/domain/domain-service/user-deactivate.ts
@@ -42,9 +42,8 @@ export class UserDeactivate {
       } else if (
         targetPair.getUserCount() < Pair.MINIIMUM_NUMBER_OF_PARTICIPANTS
       ) {
-        const leftUsers = targetPair.getUsers()
-
-        leftUsers.forEach((user) => fewestPair.addUser(user))
+        const leftUser = targetPair.getFirstUser()
+        fewestPair.addUser(leftUser)
 
         targetTeam.removePair(fewestPair.getId())
         targetTeam.addPair(fewestPair)

--- a/backend/src/domain/entity/__tests__/pair.test.ts
+++ b/backend/src/domain/entity/__tests__/pair.test.ts
@@ -37,9 +37,9 @@ describe('Pairのテスト', () => {
       expect(pair.getName()).toBe('a')
     })
 
-    it('getUsers()でペアに所属する参加者の取得が行えること', () => {
-      expect(pair.getUsers()).toContain(user1)
-      expect(pair.getUsers()).toContain(user2)
+    it('getUsersInRepository()でペアに所属する参加者の取得が行えること', () => {
+      expect(pair.getUsersInRepository()).toContain(user1)
+      expect(pair.getUsersInRepository()).toContain(user2)
     })
 
     it('getUserByUserId()でペアに所属する参加者の取得が行えること', () => {

--- a/backend/src/domain/entity/pair.ts
+++ b/backend/src/domain/entity/pair.ts
@@ -24,8 +24,8 @@ export class Pair {
     return this.name.getValue()
   }
 
-  public getUsers(): User[] {
-    return this.users
+  public getUsersInRepository(): User[] {
+    return [...this.users]
   }
 
   public getAllProperties() {
@@ -34,6 +34,10 @@ export class Pair {
       name: this.name.getValue(),
       users: this.users,
     }
+  }
+
+  public getFirstUser(): User {
+    return this.users[0]!
   }
 
   public getUserByUserId(userId: string): User {

--- a/backend/src/domain/entity/team.ts
+++ b/backend/src/domain/entity/team.ts
@@ -50,7 +50,7 @@ export class Team {
 
   public getPairByUserId(userId: string): Pair {
     const pair = this.pairs.find((pair) => {
-      return pair.getUsers().find((user) => user.getId() === userId)
+      return pair.getUserByUserId(userId)
     })
 
     if (pair) {

--- a/backend/src/infra/db/repository/user-repository.ts
+++ b/backend/src/infra/db/repository/user-repository.ts
@@ -256,7 +256,7 @@ export class UserRepository implements IUserRepository {
           in: teamEntity
             .getPairs()
             .map((pair) => {
-              return pair.getUsers().map((user) => user.getId())
+              return pair.getUsersInRepository().map((user) => user.getId())
             })
             .reduce((acc, val) => acc.concat(val), []),
         },
@@ -277,7 +277,7 @@ export class UserRepository implements IUserRepository {
               id: pair.getId(),
               name: pair.getName(),
               users: {
-                create: pair.getUsers().map((user) => {
+                create: pair.getUsersInRepository().map((user) => {
                   return {
                     id: user.getId(),
                     name: user.getName(),


### PR DESCRIPTION
### 修正内容

- mutableな配列を返してしまっているpairエンティティのgetUsers()メソッドを使用しないように修正。
  - getUsers()を使用してしまっている箇所はやりたいことをpairエンティティに実装したメソッドを使用して実現するように修正。
  - 例外としてRepositoryに永続化する際はpairに含まれているusersを使用する必要があるので、getPairs()自体は残す。
    - ただしRepositoryでしか使用しないことがわかるようにメソッド名をgetPairsInRepository()に変更。
    - また直接users配列を返すのではなくreturn [...this.users]として配列のコピーを返すように変更。